### PR TITLE
Better Delta

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Rust Toolchain Setup
-        uses: dtolnay/rust-toolchain@1.87.0
+        uses: dtolnay/rust-toolchain@1.93.1
 
       - name: Install
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ticked_async_executor"
 version = "0.3.1"
 authors = ["coder137"]
-edition = "2021"
+edition = "2024"
 description = "Local executor that runs woken async tasks when it is ticked"
 license = "Apache-2.0"
 repository = "https://github.com/coder137/ticked-async-executor"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ticked_async_executor"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["coder137"]
 edition = "2021"
 description = "Local executor that runs woken async tasks when it is ticked"
@@ -28,7 +28,7 @@ tokio = { version = "1", default-features = false, features = ["sync"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
-criterion = "0.5"
+criterion = "0.8"
 
 [[bench]]
 name = "benchmark"

--- a/README.md
+++ b/README.md
@@ -142,4 +142,3 @@ time:   [1.5688 ms 1.5692 ms 1.5697 ms]
 - [x] TickedAsyncExecutor
 - [x] SplitTickedAsyncExecutor
   - Similar to the channel API, but spawner and ticker cannot be moved to different threads 
-- [ ] Tracing

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Async Local Executor which executes woken tasks only when it is ticked
 
-MSRV: 1.87
-
 # Usage
 
 ## Default Local Executor

--- a/src/split_ticked_async_executor.rs
+++ b/src/split_ticked_async_executor.rs
@@ -161,6 +161,7 @@ where
     }
 }
 
+#[derive(Clone)]
 pub struct TickedAsyncExecutorDelta(Rc<Cell<f64>>);
 
 impl TickedAsyncExecutorDelta {

--- a/src/split_ticked_async_executor.rs
+++ b/src/split_ticked_async_executor.rs
@@ -1,5 +1,7 @@
 use std::{
+    cell::Cell,
     future::Future,
+    rc::Rc,
     sync::{
         atomic::{AtomicUsize, Ordering},
         mpsc, Arc,
@@ -58,6 +60,7 @@ impl SplitTickedAsyncExecutor {
             num_woken_tasks,
             num_spawned_tasks,
             observer,
+            delta: Rc::new(0.0.into()),
             #[cfg(feature = "tick_event")]
             tick_event_tx,
             #[cfg(feature = "timer_registration")]
@@ -158,11 +161,20 @@ where
     }
 }
 
+pub struct TickedAsyncExecutorDelta(Rc<Cell<f64>>);
+
+impl TickedAsyncExecutorDelta {
+    pub fn get(&self) -> f64 {
+        self.0.get()
+    }
+}
+
 pub struct TickedAsyncExecutorTicker<O> {
     task_rx: mpsc::Receiver<Payload>,
     num_woken_tasks: Arc<AtomicUsize>,
     num_spawned_tasks: Arc<AtomicUsize>,
     observer: O,
+    delta: Rc<Cell<f64>>,
 
     #[cfg(feature = "tick_event")]
     tick_event_tx: tokio::sync::watch::Sender<f64>,
@@ -177,7 +189,13 @@ impl<O> TickedAsyncExecutorTicker<O>
 where
     O: Fn(TaskState),
 {
+    pub fn delta(&self) -> TickedAsyncExecutorDelta {
+        TickedAsyncExecutorDelta(self.delta.clone())
+    }
+
     pub fn tick(&mut self, delta: f64, limit: Option<usize>) {
+        self.delta.replace(delta);
+
         #[cfg(feature = "tick_event")]
         let _r = self.tick_event_tx.send(delta);
 

--- a/src/split_ticked_async_executor.rs
+++ b/src/split_ticked_async_executor.rs
@@ -131,7 +131,7 @@ where
         &self,
         identifier: TaskIdentifier,
         future: F,
-    ) -> DroppableFuture<F, impl Fn()>
+    ) -> DroppableFuture<F, impl Fn() + use<F, O>>
     where
         F: Future,
     {
@@ -149,7 +149,10 @@ where
         })
     }
 
-    fn runnable_schedule_cb(&self, identifier: TaskIdentifier) -> impl Fn(async_task::Runnable) {
+    fn runnable_schedule_cb(
+        &self,
+        identifier: TaskIdentifier,
+    ) -> impl Fn(async_task::Runnable) + use<O> {
         let sender = self.task_tx.clone();
         let num_woken_tasks = self.num_woken_tasks.clone();
         let observer = self.observer.clone();

--- a/src/split_ticked_async_executor.rs
+++ b/src/split_ticked_async_executor.rs
@@ -168,6 +168,10 @@ impl TickedAsyncExecutorDelta {
     pub fn get(&self) -> f64 {
         self.0.get()
     }
+
+    pub fn inner(self) -> Rc<Cell<f64>> {
+        self.0
+    }
 }
 
 pub struct TickedAsyncExecutorTicker<O> {


### PR DESCRIPTION
- Added `Rc<Cell<f64>>` instead of `tokio::watch` channel for delta updates
- Single threaded so `Rc<Cell<f64>>` is more performant
- NOTE, Eventually phase out `tokio::watch` channel