### PR TITLE
Flume channel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,11 +24,17 @@ timer_registration = []
 [dependencies]
 async-task = "4.7"
 pin-project = "1"
+flume = { version = "0.12" }
+
 tokio = { version = "1", default-features = false, features = ["sync"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
 criterion = "0.8"
+
+tracing = "0.1"
+tracing-subscriber = "0.3"
+tracing-tracy = { version = "0.11.4", features = ["fibers"] }
 
 [[bench]]
 name = "benchmark"

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 
 use ticked_async_executor::TickedAsyncExecutor;
 

--- a/examples/simple_with_tracy.rs
+++ b/examples/simple_with_tracy.rs
@@ -1,0 +1,51 @@
+use ticked_async_executor::TickedAsyncExecutor;
+use tracing::Instrument;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+use tracing_tracy::client::ProfiledAllocator;
+
+#[global_allocator]
+static GLOBAL: ProfiledAllocator<std::alloc::System> =
+    ProfiledAllocator::new(std::alloc::System, 100);
+
+async fn async_yield_now() {
+    let mut yielded = false;
+    std::future::poll_fn(|cx| {
+        if yielded {
+            std::task::Poll::Ready(())
+        } else {
+            yielded = true;
+            cx.waker().wake_by_ref();
+            std::task::Poll::Pending
+        }
+    })
+    .await;
+}
+
+fn main() {
+    let tracy_layer = tracing_tracy::TracyLayer::default();
+    tracing_subscriber::registry().with(tracy_layer).init();
+
+    let mut executor = TickedAsyncExecutor::default();
+
+    for i in 0..1 {
+        executor
+            .spawn_local(
+                "MyIdentifier",
+                async move {
+                    let mut counter = 0;
+                    loop {
+                        println!("COUNT: {}", counter);
+                        counter += 1;
+                        async_yield_now().await;
+                    }
+                }
+                .instrument(tracing::info_span!("Spawn", i)),
+            )
+            .detach();
+    }
+
+    loop {
+        std::thread::sleep(std::time::Duration::from_millis(16));
+        executor.tick(16.00, None);
+    }
+}

--- a/src/split_ticked_async_executor.rs
+++ b/src/split_ticked_async_executor.rs
@@ -36,7 +36,6 @@ impl SplitTickedAsyncExecutor {
         O: Fn(TaskState) + Clone + Send + Sync + 'static,
     {
         let (task_tx, task_rx) = flume::unbounded();
-        let num_woken_tasks = Arc::new(AtomicUsize::new(0));
         let num_spawned_tasks = Arc::new(AtomicUsize::new(0));
 
         #[cfg(feature = "tick_event")]
@@ -47,7 +46,6 @@ impl SplitTickedAsyncExecutor {
 
         let spawner = TickedAsyncExecutorSpawner {
             task_tx,
-            num_woken_tasks: num_woken_tasks.clone(),
             num_spawned_tasks: num_spawned_tasks.clone(),
             observer: observer.clone(),
             #[cfg(feature = "tick_event")]
@@ -57,7 +55,6 @@ impl SplitTickedAsyncExecutor {
         };
         let ticker = TickedAsyncExecutorTicker {
             task_rx,
-            num_woken_tasks,
             num_spawned_tasks,
             observer,
             delta: Rc::new(0.0.into()),
@@ -74,7 +71,6 @@ impl SplitTickedAsyncExecutor {
 
 pub struct TickedAsyncExecutorSpawner<O> {
     task_tx: flume::Sender<Payload>,
-    num_woken_tasks: Arc<AtomicUsize>,
 
     num_spawned_tasks: Arc<AtomicUsize>,
     // TODO, Or we need a Single Producer - Multi Consumer channel i.e Broadcast channel
@@ -154,11 +150,9 @@ where
         identifier: TaskIdentifier,
     ) -> impl Fn(async_task::Runnable) + use<O> {
         let task_tx = self.task_tx.clone();
-        let num_woken_tasks = self.num_woken_tasks.clone();
         let observer = self.observer.clone();
         move |runnable| {
             task_tx.send((identifier.clone(), runnable)).unwrap_or(());
-            num_woken_tasks.fetch_add(1, Ordering::Relaxed);
             observer(TaskState::Wake(identifier.clone()));
         }
     }
@@ -179,7 +173,6 @@ impl TickedAsyncExecutorDelta {
 
 pub struct TickedAsyncExecutorTicker<O> {
     task_rx: flume::Receiver<Payload>,
-    num_woken_tasks: Arc<AtomicUsize>,
     num_spawned_tasks: Arc<AtomicUsize>,
     observer: O,
     delta: Rc<Cell<f64>>,
@@ -210,7 +203,7 @@ where
         #[cfg(feature = "timer_registration")]
         self.timer_registration_tick(delta);
 
-        let mut num_woken_tasks = self.num_woken_tasks.load(Ordering::Relaxed);
+        let mut num_woken_tasks = self.task_rx.len();
         if let Some(limit) = limit {
             // Woken tasks should not exceed the allowed limit
             num_woken_tasks = num_woken_tasks.min(limit);
@@ -223,8 +216,6 @@ where
                 (self.observer)(TaskState::Tick(identifier, delta));
                 runnable.run();
             });
-        self.num_woken_tasks
-            .fetch_sub(num_woken_tasks, Ordering::Relaxed);
     }
 
     pub fn wait_till_completed(&mut self, constant_delta: f64) {

--- a/src/split_ticked_async_executor.rs
+++ b/src/split_ticked_async_executor.rs
@@ -42,7 +42,7 @@ impl SplitTickedAsyncExecutor {
         let (tick_event_tx, tick_event_rx) = tokio::sync::watch::channel(1.0);
 
         #[cfg(feature = "timer_registration")]
-        let (timer_registration_tx, timer_registration_rx) = mpsc::channel();
+        let (timer_registration_tx, timer_registration_rx) = flume::unbounded();
 
         let spawner = TickedAsyncExecutorSpawner {
             task_tx,
@@ -81,7 +81,7 @@ pub struct TickedAsyncExecutorSpawner<O> {
     #[cfg(feature = "tick_event")]
     tick_event_rx: tokio::sync::watch::Receiver<f64>,
     #[cfg(feature = "timer_registration")]
-    timer_registration_tx: mpsc::Sender<(f64, tokio::sync::oneshot::Sender<()>)>,
+    timer_registration_tx: flume::Sender<(f64, tokio::sync::oneshot::Sender<()>)>,
 }
 
 impl<O> TickedAsyncExecutorSpawner<O>
@@ -181,7 +181,7 @@ pub struct TickedAsyncExecutorTicker<O> {
     tick_event_tx: tokio::sync::watch::Sender<f64>,
 
     #[cfg(feature = "timer_registration")]
-    timer_registration_rx: mpsc::Receiver<(f64, tokio::sync::oneshot::Sender<()>)>,
+    timer_registration_rx: flume::Receiver<(f64, tokio::sync::oneshot::Sender<()>)>,
     #[cfg(feature = "timer_registration")]
     timers: Vec<(f64, tokio::sync::oneshot::Sender<()>)>,
 }

--- a/src/split_ticked_async_executor.rs
+++ b/src/split_ticked_async_executor.rs
@@ -3,8 +3,9 @@ use std::{
     future::Future,
     rc::Rc,
     sync::{
+        Arc,
         atomic::{AtomicUsize, Ordering},
-        mpsc, Arc,
+        mpsc,
     },
 };
 

--- a/src/task_identifier.rs
+++ b/src/task_identifier.rs
@@ -3,8 +3,15 @@ use std::sync::Arc;
 /// Cheaply clonable TaskIdentifier
 #[derive(Debug, Clone)]
 pub enum TaskIdentifier {
+    None,
     Literal(&'static str),
     Arc(Arc<String>),
+}
+
+impl From<()> for TaskIdentifier {
+    fn from(_value: ()) -> Self {
+        Self::None
+    }
 }
 
 impl From<&'static str> for TaskIdentifier {
@@ -28,6 +35,7 @@ impl From<Arc<String>> for TaskIdentifier {
 impl std::fmt::Display for TaskIdentifier {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            TaskIdentifier::None => write!(f, "[None]"),
             TaskIdentifier::Literal(data) => write!(f, "{data}"),
             TaskIdentifier::Arc(data) => write!(f, "{data}"),
         }
@@ -40,6 +48,9 @@ mod tests {
 
     #[test]
     fn test_display() {
+        let identifier = TaskIdentifier::from(());
+        assert_eq!(identifier.to_string(), "[None]");
+
         let identifier = TaskIdentifier::from("Hello World");
         assert_eq!(identifier.to_string(), "Hello World");
 

--- a/src/ticked_async_executor.rs
+++ b/src/ticked_async_executor.rs
@@ -303,6 +303,7 @@ mod tests {
         }
 
         for i in 0..10 {
+            println!("Tick {i}");
             let num_tasks = executor.num_tasks();
             assert_eq!(num_tasks, 10 - i);
             executor.tick(0.1, Some(1));

--- a/src/ticked_timer_from_timer_registration.rs
+++ b/src/ticked_timer_from_timer_registration.rs
@@ -1,23 +1,21 @@
-use std::sync::mpsc;
-
 pub struct TickedTimerFromTimerRegistration {
-    timer_registration_tx: mpsc::Sender<(f64, tokio::sync::oneshot::Sender<()>)>,
+    timer_registration_tx: flume::Sender<(f64, tokio::sync::oneshot::Sender<()>)>,
 }
 
 impl TickedTimerFromTimerRegistration {
     pub fn new(
-        timer_registration_tx: mpsc::Sender<(f64, tokio::sync::oneshot::Sender<()>)>,
+        timer_registration_tx: flume::Sender<(f64, tokio::sync::oneshot::Sender<()>)>,
     ) -> Self {
         Self {
             timer_registration_tx,
         }
     }
 
-    pub async fn sleep_for(&self, duration_in_ms: f64) {
+    pub async fn sleep_for(&self, duration: f64) {
         let (tx, rx) = tokio::sync::oneshot::channel();
         let _ignore = async {
             self.timer_registration_tx
-                .send((duration_in_ms, tx))
+                .send((duration, tx))
                 .map_err(|_| ())?;
             rx.await.map_err(|_| ())?;
             Ok::<(), ()>(())


### PR DESCRIPTION
Flume channels do not allocate on every send, since it increases its internal capacity depending on the number of messages sent.

# Main

- Use flume channel instead of std channel for sync
- Removed `num_woken_tasks` tracker variable, shift to using `len` API provided by `flume::Receiver`

# Misc

- Added None type to TaskIdentifier
- Added simple example using tracing-tracy (for memory profiling)
