### PR TITLE
TickedAsyncExecutorSpawner: !Send and Clone

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Rust Toolchain Setup
         uses: dtolnay/rust-toolchain@1.93.1
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Upload coverage reports to Codecov
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        uses: codecov/codecov-action@v4.0.1
+        uses: codecov/codecov-action@v6
         with:
             token: ${{ secrets.CODECOV_TOKEN }}
             files: target/cobertura.xml

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ spawner.spawn_local("MyIdentifier", async move {}).detach();
 assert_eq!(spawner.num_tasks(), 1);
 ticker.tick(DELTA, None);
 assert_eq!(spawner.num_tasks(), 0);
+
+// spawner can be cloned
+let spawner_clone = spawner.clone();
 ```
 
 ## Limit the number of woken tasks run per tick

--- a/src/split_ticked_async_executor.rs
+++ b/src/split_ticked_async_executor.rs
@@ -72,11 +72,7 @@ impl SplitTickedAsyncExecutor {
 
 pub struct TickedAsyncExecutorSpawner<O> {
     task_tx: flume::Sender<Payload>,
-
     num_spawned_tasks: Arc<AtomicUsize>,
-    // TODO, Or we need a Single Producer - Multi Consumer channel i.e Broadcast channel
-    // Broadcast recv channel should be notified when there are new messages in the queue
-    // Broadcast channel must also be able to remove older/stale messages (like a RingBuffer)
     observer: O,
 
     #[cfg(feature = "tick_event")]

--- a/src/split_ticked_async_executor.rs
+++ b/src/split_ticked_async_executor.rs
@@ -263,3 +263,15 @@ where
             });
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_split_ticked_async_executor_spawner_clone() {
+        let (spawner, _ticker) = SplitTickedAsyncExecutor::default();
+
+        let _spawner_clone = spawner.clone();
+    }
+}

--- a/src/split_ticked_async_executor.rs
+++ b/src/split_ticked_async_executor.rs
@@ -52,6 +52,7 @@ impl SplitTickedAsyncExecutor {
             tick_event_rx,
             #[cfg(feature = "timer_registration")]
             timer_registration_tx,
+            _not_send: std::marker::PhantomData::default(),
         };
         let ticker = TickedAsyncExecutorTicker {
             task_rx,
@@ -82,6 +83,24 @@ pub struct TickedAsyncExecutorSpawner<O> {
     tick_event_rx: tokio::sync::watch::Receiver<f64>,
     #[cfg(feature = "timer_registration")]
     timer_registration_tx: flume::Sender<(f64, tokio::sync::oneshot::Sender<()>)>,
+
+    // https://github.com/rust-lang/rust/issues/68318
+    _not_send: std::marker::PhantomData<*const ()>,
+}
+
+impl<O: Clone> Clone for TickedAsyncExecutorSpawner<O> {
+    fn clone(&self) -> Self {
+        Self {
+            task_tx: self.task_tx.clone(),
+            num_spawned_tasks: self.num_spawned_tasks.clone(),
+            observer: self.observer.clone(),
+            #[cfg(feature = "tick_event")]
+            tick_event_rx: self.tick_event_rx.clone(),
+            #[cfg(feature = "timer_registration")]
+            timer_registration_tx: self.timer_registration_tx.clone(),
+            _not_send: self._not_send.clone(),
+        }
+    }
 }
 
 impl<O> TickedAsyncExecutorSpawner<O>

--- a/src/ticked_async_executor.rs
+++ b/src/ticked_async_executor.rs
@@ -160,6 +160,7 @@ mod tests {
         let mut executor = TickedAsyncExecutor::default();
 
         let delta = executor.delta();
+        let _delta_inner = delta.clone().inner();
 
         executor
             .spawn_local("MyIdentifier", async move {


### PR DESCRIPTION
# Main

- Make `TickedAsyncExecutorSpawner` !Send and Clone
- `TickedAsyncExecutorTicker` is !Send and !Clone by default (!Send due to Rc usage)

# Misc

- Updated CI/CD
- Updated README
