### PR TITLE
Notification Timer: TickedTimerFromTimerRegistration 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ticked_async_executor"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["coder137"]
 edition = "2024"
 description = "Local executor that runs woken async tasks when it is ticked"
@@ -34,7 +34,9 @@ criterion = "0.8"
 
 tracing = "0.1"
 tracing-subscriber = "0.3"
-tracing-tracy = { version = "0.11.4", features = ["fibers"] }
+tracing-tracy = { version = "0.11.4", features = ["fibers", "flush-on-exit"] }
+
+ctrlc = "3.5.2"
 
 [[bench]]
 name = "benchmark"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,10 @@ ctrlc = "3.5.2"
 [[bench]]
 name = "benchmark"
 harness = false
+
+[[example]]
+name = "simple_with_tracy"
+
+[[example]]
+name = "timer_registration_with_tracy"
+required-features = ["timer_registration"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ticked_async_executor"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["coder137"]
 edition = "2024"
 description = "Local executor that runs woken async tasks when it is ticked"

--- a/README.md
+++ b/README.md
@@ -142,4 +142,9 @@ time:   [1.5688 ms 1.5692 ms 1.5697 ms]
 
 - [x] TickedAsyncExecutor
 - [x] SplitTickedAsyncExecutor
-  - Similar to the channel API, but spawner and ticker cannot be moved to different threads 
+  - Similar to the channel API
+  - Spawner is !Send + Clone
+  - Ticker is !Send + !Clone
+- [x] Timers
+  - [x] Notification based: TickedTimerFromTimerRegistration
+  - [x] Polling based: TickedTimerFromTickEvent

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -79,7 +79,7 @@ fn timer_from_tick_event_benchmark(c: &mut Criterion) {
             let timer = executor.create_timer_from_tick_event();
             executor
                 .spawn_local("empty", async move {
-                    timer.sleep_for(1.0).await;
+                    timer.sleep_for(1.0).await.unwrap_or_default();
                 })
                 .detach();
 
@@ -96,7 +96,7 @@ fn timer_from_tick_event_benchmark(c: &mut Criterion) {
                 let timer = executor.create_timer_from_tick_event();
                 executor
                     .spawn_local("empty", async move {
-                        timer.sleep_for(1.0).await;
+                        timer.sleep_for(1.0).await.unwrap_or_default();
                     })
                     .detach();
             }

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -116,7 +116,7 @@ fn timer_from_timer_registration_benchmark(c: &mut Criterion) {
             let timer = executor.create_timer_from_timer_registration();
             executor
                 .spawn_local("empty", async move {
-                    timer.sleep_for(1.0).await;
+                    timer.sleep_for(1.0).await.unwrap_or_default();
                 })
                 .detach();
 
@@ -133,7 +133,7 @@ fn timer_from_timer_registration_benchmark(c: &mut Criterion) {
                 let timer = executor.create_timer_from_timer_registration();
                 executor
                     .spawn_local("empty", async move {
-                        timer.sleep_for(1.0).await;
+                        timer.sleep_for(1.0).await.unwrap_or_default();
                     })
                     .detach();
             }

--- a/examples/simple_with_tracy.rs
+++ b/examples/simple_with_tracy.rs
@@ -1,5 +1,4 @@
 use ticked_async_executor::TickedAsyncExecutor;
-use tracing::Instrument;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use tracing_tracy::client::ProfiledAllocator;
 
@@ -21,31 +20,47 @@ async fn async_yield_now() {
     .await;
 }
 
-fn main() {
+fn main() -> Result<(), ()> {
+    let shutdown = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let shutdown_clone = shutdown.clone();
+    ctrlc::set_handler(move || {
+        shutdown_clone.store(true, std::sync::atomic::Ordering::Relaxed);
+    })
+    .unwrap();
+
     let tracy_layer = tracing_tracy::TracyLayer::default();
     tracing_subscriber::registry().with(tracy_layer).init();
 
     let mut executor = TickedAsyncExecutor::default();
 
-    for i in 0..1 {
-        executor
-            .spawn_local(
-                "MyIdentifier",
-                async move {
-                    let mut counter = 0;
-                    loop {
-                        println!("COUNT: {}", counter);
-                        counter += 1;
-                        async_yield_now().await;
-                    }
+    executor
+        .spawn_local((), async move {
+            let mut counter = 0;
+            loop {
+                println!("COUNT: {}", counter);
+                counter += 1;
+                async_yield_now().await;
+                if shutdown.load(std::sync::atomic::Ordering::Relaxed) {
+                    println!("SHUTDOWN");
+                    break;
                 }
-                .instrument(tracing::info_span!("Spawn", i)),
-            )
-            .detach();
-    }
+            }
+        })
+        .detach();
 
     loop {
         std::thread::sleep(std::time::Duration::from_millis(16));
         executor.tick(16.00, None);
+        if executor.num_tasks() == 0 {
+            break;
+        }
     }
+
+    let profiler_connected = tracing_tracy::client::Client::is_connected();
+    println!("Profiler Running: {profiler_connected}");
+    if !profiler_connected {
+        // Due to "flush-on-exit" we need to force exit
+        std::process::exit(1);
+    }
+    Ok(())
 }

--- a/examples/simple_with_tracy.rs
+++ b/examples/simple_with_tracy.rs
@@ -31,7 +31,9 @@ fn main() -> Result<(), ()> {
     let tracy_layer = tracing_tracy::TracyLayer::default();
     tracing_subscriber::registry().with(tracy_layer).init();
 
-    let mut executor = TickedAsyncExecutor::default();
+    let mut executor = TickedAsyncExecutor::new(|state| {
+        tracing::info!("{state:?}");
+    });
 
     executor
         .spawn_local((), async move {

--- a/examples/timer_registration_with_tracy.rs
+++ b/examples/timer_registration_with_tracy.rs
@@ -1,0 +1,64 @@
+use ticked_async_executor::TickedAsyncExecutor;
+use tracing::Instrument;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+use tracing_tracy::client::ProfiledAllocator;
+
+#[global_allocator]
+static GLOBAL: ProfiledAllocator<std::alloc::System> =
+    ProfiledAllocator::new(std::alloc::System, 100);
+
+fn main() -> Result<(), ()> {
+    let shutdown = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let shutdown_clone = shutdown.clone();
+    ctrlc::set_handler(move || {
+        shutdown_clone.store(true, std::sync::atomic::Ordering::Relaxed);
+    })
+    .unwrap();
+
+    let tracy_layer = tracing_tracy::TracyLayer::default();
+    tracing_subscriber::registry().with(tracy_layer).init();
+
+    let mut executor = TickedAsyncExecutor::new(|state| {
+        tracing::info!("{state:?}");
+    });
+
+    let timer = executor.create_timer_from_timer_registration();
+    for i in 0..10 {
+        let timer_clone = timer.clone();
+        let shutdown_clone = shutdown.clone();
+        executor
+            .spawn_local(
+                (),
+                async move {
+                    let mut counter = 0;
+                    loop {
+                        println!("COUNT: {}", counter);
+                        counter += 1;
+                        timer_clone.sleep_for(160.0).await;
+                        if shutdown_clone.load(std::sync::atomic::Ordering::Relaxed) {
+                            println!("SHUTDOWN: {i}");
+                            break;
+                        }
+                    }
+                }
+                .instrument(tracing::info_span!("Task", name = i)),
+            )
+            .detach();
+    }
+
+    loop {
+        std::thread::sleep(std::time::Duration::from_millis(16));
+        executor.tick(16.00, None);
+        if executor.num_tasks() == 0 {
+            break;
+        }
+    }
+
+    let profiler_connected = tracing_tracy::client::Client::is_connected();
+    println!("Profiler Running: {profiler_connected}");
+    if !profiler_connected {
+        // Due to "flush-on-exit" we need to force exit
+        std::process::exit(1);
+    }
+    Ok(())
+}

--- a/examples/timer_registration_with_tracy.rs
+++ b/examples/timer_registration_with_tracy.rs
@@ -34,7 +34,7 @@ fn main() -> Result<(), ()> {
                     loop {
                         println!("COUNT: {}", counter);
                         counter += 1;
-                        timer_clone.sleep_for(160.0).await;
+                        timer_clone.sleep_for(160.0).await.unwrap_or_default();
                         if shutdown_clone.load(std::sync::atomic::Ordering::Relaxed) {
                             println!("SHUTDOWN: {i}");
                             break;

--- a/src/split_ticked_async_executor.rs
+++ b/src/split_ticked_async_executor.rs
@@ -52,7 +52,7 @@ impl SplitTickedAsyncExecutor {
             tick_event_rx,
             #[cfg(feature = "timer_registration")]
             timer_registration_tx,
-            _not_send: std::marker::PhantomData::default(),
+            _not_send: std::marker::PhantomData,
         };
         let ticker = TickedAsyncExecutorTicker {
             task_rx,
@@ -78,7 +78,7 @@ pub struct TickedAsyncExecutorSpawner<O> {
     #[cfg(feature = "tick_event")]
     tick_event_rx: tokio::sync::watch::Receiver<f64>,
     #[cfg(feature = "timer_registration")]
-    timer_registration_tx: flume::Sender<(f64, tokio::sync::oneshot::Sender<()>)>,
+    timer_registration_tx: flume::Sender<(f64, std::task::Waker)>,
 
     // https://github.com/rust-lang/rust/issues/68318
     _not_send: std::marker::PhantomData<*const ()>,
@@ -94,7 +94,7 @@ impl<O: Clone> Clone for TickedAsyncExecutorSpawner<O> {
             tick_event_rx: self.tick_event_rx.clone(),
             #[cfg(feature = "timer_registration")]
             timer_registration_tx: self.timer_registration_tx.clone(),
-            _not_send: self._not_send.clone(),
+            _not_send: self._not_send,
         }
     }
 }
@@ -196,9 +196,10 @@ pub struct TickedAsyncExecutorTicker<O> {
     tick_event_tx: tokio::sync::watch::Sender<f64>,
 
     #[cfg(feature = "timer_registration")]
-    timer_registration_rx: flume::Receiver<(f64, tokio::sync::oneshot::Sender<()>)>,
+    timer_registration_rx: flume::Receiver<(f64, std::task::Waker)>,
+
     #[cfg(feature = "timer_registration")]
-    timers: Vec<(f64, tokio::sync::oneshot::Sender<()>)>,
+    timers: Vec<(f64, std::task::Waker)>,
 }
 
 impl<O> TickedAsyncExecutorTicker<O>
@@ -250,16 +251,17 @@ where
         if self.timers.is_empty() {
             return;
         }
-        self.timers.iter_mut().for_each(|(elapsed, _)| {
-            *elapsed -= delta;
-        });
 
+        // Update timers with delta
         // Extract timers that have elapsed
         // Notify corresponding channels
         self.timers
-            .extract_if(.., |(elapsed, _)| *elapsed <= 0.0)
-            .for_each(|(_, rx)| {
-                let _ignore = rx.send(());
+            .extract_if(.., |(elapsed, _)| {
+                *elapsed -= delta;
+                *elapsed <= 0.0
+            })
+            .for_each(|(_, waker)| {
+                waker.wake();
             });
     }
 }

--- a/src/ticked_async_executor.rs
+++ b/src/ticked_async_executor.rs
@@ -269,7 +269,7 @@ mod tests {
             let timer = executor.create_timer_from_timer_registration();
             executor
                 .spawn_local("LocalTimer", async move {
-                    timer.sleep_for(256.0).await;
+                    timer.sleep_for(256.0).await.unwrap_or_default();
                 })
                 .detach();
         }

--- a/src/ticked_async_executor.rs
+++ b/src/ticked_async_executor.rs
@@ -192,7 +192,7 @@ mod tests {
             let timer = executor.create_timer_from_tick_event();
             executor
                 .spawn_local("LocalTimer", async move {
-                    timer.sleep_for(256.0).await;
+                    timer.sleep_for(256.0).await.unwrap_or_default();
                 })
                 .detach();
         }
@@ -218,14 +218,14 @@ mod tests {
         let timer = executor.create_timer_from_tick_event();
         executor
             .spawn_local("LocalFuture1", async move {
-                timer.sleep_for(1000.0).await;
+                timer.sleep_for(1000.0).await.unwrap_or_default();
             })
             .detach();
 
         let timer = executor.create_timer_from_tick_event();
         executor
             .spawn_local("LocalFuture2", async move {
-                timer.sleep_for(1000.0).await;
+                timer.sleep_for(1000.0).await.unwrap_or_default();
             })
             .detach();
 

--- a/src/ticked_timer_from_tick_event.rs
+++ b/src/ticked_timer_from_tick_event.rs
@@ -1,3 +1,6 @@
+/// DO NOT USE
+///
+/// Use `TickedTimerFromTimerRegistration` gated under the `timer_registration` feature
 pub struct TickedTimerFromTickEvent {
     tick_event_rx: tokio::sync::watch::Receiver<f64>,
 }
@@ -7,19 +10,61 @@ impl TickedTimerFromTickEvent {
         Self { tick_event_rx }
     }
 
-    pub async fn sleep_for(mut self, mut duration_in_ms: f64) {
+    pub async fn sleep_for(mut self, mut duration_in_ms: f64) -> Result<(), ()> {
         loop {
             let _r = self.tick_event_rx.changed().await;
             if _r.is_err() {
                 // This means that the executor supplying the delta channel has shutdown
                 // We must stop waiting gracefully
-                break;
+                break Err(());
             }
             let current_dt = *self.tick_event_rx.borrow_and_update();
             duration_in_ms -= current_dt;
             if duration_in_ms <= 0.0 {
-                break;
+                break Ok(());
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{SplitTickedAsyncExecutor, TickedAsyncExecutor};
+
+    #[test]
+    fn test_timer_tick_success() {
+        let mut executor = TickedAsyncExecutor::default();
+
+        let timer = executor.create_timer_from_tick_event();
+        executor
+            .spawn_local((), async move {
+                println!("TASK BEFORE");
+                timer.sleep_for(10.0).await.unwrap_or_default();
+                println!("TASK AFTER");
+            })
+            .detach();
+
+        for i in 0..=10 {
+            println!("TICK BEFORE: {i}");
+            executor.tick(1.0, None);
+            println!("TICK AFTER: {i}");
+        }
+        assert_eq!(executor.num_tasks(), 0);
+    }
+
+    #[test]
+    fn test_timer_tick_failure() {
+        let (spawner, ticker) = SplitTickedAsyncExecutor::default();
+
+        let timer = spawner.create_timer_from_tick_event();
+        drop(ticker);
+
+        let timer_future = timer.sleep_for(10.0);
+        let mut timer_future = std::pin::pin!(timer_future);
+
+        let waker = std::task::Waker::noop();
+        let mut ctx = std::task::Context::from_waker(waker);
+        let status = timer_future.as_mut().poll(&mut ctx);
+        assert_eq!(status, std::task::Poll::Ready(Err(())));
     }
 }

--- a/src/ticked_timer_from_tick_event.rs
+++ b/src/ticked_timer_from_tick_event.rs
@@ -1,6 +1,4 @@
-/// DO NOT USE
-///
-/// Use `TickedTimerFromTimerRegistration` gated under the `timer_registration` feature
+#[derive(Clone)]
 pub struct TickedTimerFromTickEvent {
     tick_event_rx: tokio::sync::watch::Receiver<f64>,
 }

--- a/src/ticked_timer_from_timer_registration.rs
+++ b/src/ticked_timer_from_timer_registration.rs
@@ -51,17 +51,17 @@ impl std::future::Future for SleepFuture {
 
 #[cfg(test)]
 mod tests {
-    use crate::TickedAsyncExecutor;
+    use crate::{SplitTickedAsyncExecutor, TickedAsyncExecutor};
 
     #[test]
-    fn test_timer_registration() {
+    fn test_timer_registration_success() {
         let mut executor = TickedAsyncExecutor::default();
 
-        let t = executor.create_timer_from_timer_registration();
+        let timer = executor.create_timer_from_timer_registration();
         executor
             .spawn_local((), async move {
                 println!("TASK BEFORE");
-                t.sleep_for(10.0).await.unwrap_or_default();
+                timer.sleep_for(10.0).await.unwrap_or_default();
                 println!("TASK AFTER");
             })
             .detach();
@@ -72,5 +72,20 @@ mod tests {
             println!("TICK AFTER: {i}");
         }
         assert_eq!(executor.num_tasks(), 0);
+    }
+
+    #[test]
+    fn test_timer_registration_failure() {
+        let (spawner, ticker) = SplitTickedAsyncExecutor::default();
+
+        let timer = spawner.create_timer_from_timer_registration();
+
+        let mut timer_future = timer.sleep_for(10.0);
+        drop(ticker);
+
+        let waker = std::task::Waker::noop();
+        let mut ctx = std::task::Context::from_waker(waker);
+        let status = std::pin::pin!(&mut timer_future).poll(&mut ctx);
+        assert_eq!(status, std::task::Poll::Ready(Err(())));
     }
 }

--- a/src/ticked_timer_from_timer_registration.rs
+++ b/src/ticked_timer_from_timer_registration.rs
@@ -1,25 +1,76 @@
+#[derive(Clone)]
 pub struct TickedTimerFromTimerRegistration {
-    timer_registration_tx: flume::Sender<(f64, tokio::sync::oneshot::Sender<()>)>,
+    timer_registration_tx: flume::Sender<(f64, std::task::Waker)>,
 }
 
 impl TickedTimerFromTimerRegistration {
-    pub fn new(
-        timer_registration_tx: flume::Sender<(f64, tokio::sync::oneshot::Sender<()>)>,
-    ) -> Self {
+    pub fn new(timer_registration_tx: flume::Sender<(f64, std::task::Waker)>) -> Self {
         Self {
             timer_registration_tx,
         }
     }
 
-    pub async fn sleep_for(&self, duration: f64) {
-        let (tx, rx) = tokio::sync::oneshot::channel();
-        let _ignore = async {
-            self.timer_registration_tx
-                .send((duration, tx))
-                .map_err(|_| ())?;
-            rx.await.map_err(|_| ())?;
-            Ok::<(), ()>(())
+    pub fn sleep_for(&self, duration: f64) -> SleepFuture {
+        SleepFuture {
+            tx: self.timer_registration_tx.clone(),
+            duration,
+            send: true,
         }
-        .await;
+    }
+}
+
+pub struct SleepFuture {
+    tx: flume::Sender<(f64, std::task::Waker)>,
+    duration: f64,
+
+    // state
+    send: bool,
+}
+
+impl std::future::Future for SleepFuture {
+    type Output = Result<(), ()>;
+
+    fn poll(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        if self.send {
+            self.send = false;
+            let waker = cx.waker().clone();
+            let _r = self.tx.send((self.duration, waker));
+            if _r.is_err() {
+                std::task::Poll::Ready(Err(()))
+            } else {
+                std::task::Poll::Pending
+            }
+        } else {
+            std::task::Poll::Ready(Ok(()))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::TickedAsyncExecutor;
+
+    #[test]
+    fn test_timer_registration() {
+        let mut executor = TickedAsyncExecutor::default();
+
+        let t = executor.create_timer_from_timer_registration();
+        executor
+            .spawn_local((), async move {
+                println!("TASK BEFORE");
+                t.sleep_for(10.0).await.unwrap_or_default();
+                println!("TASK AFTER");
+            })
+            .detach();
+
+        for i in 0..=10 {
+            println!("TICK BEFORE: {i}");
+            executor.tick(1.0, None);
+            println!("TICK AFTER: {i}");
+        }
+        assert_eq!(executor.num_tasks(), 0);
     }
 }


### PR DESCRIPTION
# Main
- `TickedTimerFromTimerRegistration` does not causes heap allocation during runtime (uses `Waker` instead of `tokio::oneshot` channel)
- Update simple example 
- Added timer_registration example
- `sleep_for` timer API now returns `Result<(), ()>`

# Misc
- Added unit tests
- Updated README
- Updated from 0.3 to 0.4