### PR TITLE
TaskId and UserId

### DIFF
--- a/src/droppable_future.rs
+++ b/src/droppable_future.rs
@@ -6,27 +6,30 @@ use pin_project::{pin_project, pinned_drop};
 pub struct DroppableFuture<F, D>
 where
     F: Future,
-    D: Fn(),
+    D: FnOnce(),
 {
     #[pin]
     future: F,
-    on_drop: D,
+    on_drop: Option<D>,
 }
 
 impl<F, D> DroppableFuture<F, D>
 where
     F: Future,
-    D: Fn(),
+    D: FnOnce(),
 {
     pub fn new(future: F, on_drop: D) -> Self {
-        Self { future, on_drop }
+        Self {
+            future,
+            on_drop: Some(on_drop),
+        }
     }
 }
 
 impl<F, D> Future for DroppableFuture<F, D>
 where
     F: Future,
-    D: Fn(),
+    D: FnOnce(),
 {
     type Output = F::Output;
 
@@ -43,9 +46,12 @@ where
 impl<F, D> PinnedDrop for DroppableFuture<F, D>
 where
     F: Future,
-    D: Fn(),
+    D: FnOnce(),
 {
     fn drop(self: Pin<&mut Self>) {
-        (self.on_drop)();
+        let this = self.project();
+        if let Some(on_drop) = this.on_drop.take() {
+            (on_drop)();
+        }
     }
 }

--- a/src/split_ticked_async_executor.rs
+++ b/src/split_ticked_async_executor.rs
@@ -8,19 +8,19 @@ use std::{
     },
 };
 
-use crate::{DroppableFuture, TaskIdentifier};
+use crate::{DroppableFuture, TaskId, UserId};
 
 #[derive(Debug)]
 pub enum TaskState {
-    Spawn(TaskIdentifier),
-    Wake(TaskIdentifier),
-    TickStart(TaskIdentifier, f64),
-    TickEnd(TaskIdentifier),
-    Drop(TaskIdentifier),
+    Spawn(TaskId),
+    Wake(TaskId),
+    TickStart(TaskId, f64),
+    TickEnd(TaskId),
+    Drop(TaskId),
 }
 
 pub type Task<T> = async_task::Task<T>;
-type Payload = (TaskIdentifier, async_task::Runnable);
+type Payload = (TaskId, async_task::Runnable);
 
 pub struct SplitTickedAsyncExecutor;
 
@@ -51,6 +51,7 @@ impl SplitTickedAsyncExecutor {
             num_spawned_tasks: num_spawned_tasks.clone(),
             observer: observer.clone(),
             delta: delta.clone(),
+            counter: Rc::new(Cell::new(0)),
             #[cfg(feature = "tick_event")]
             tick_event_rx,
             #[cfg(feature = "timer_registration")]
@@ -91,6 +92,7 @@ pub struct TickedAsyncExecutorSpawner<O> {
     num_spawned_tasks: Arc<AtomicUsize>,
     observer: O,
     delta: Rc<Cell<f64>>,
+    counter: Rc<Cell<u64>>,
 
     #[cfg(feature = "tick_event")]
     tick_event_rx: tokio::sync::watch::Receiver<f64>,
@@ -108,6 +110,7 @@ impl<O: Clone> Clone for TickedAsyncExecutorSpawner<O> {
             num_spawned_tasks: self.num_spawned_tasks.clone(),
             observer: self.observer.clone(),
             delta: self.delta.clone(),
+            counter: self.counter.clone(),
             #[cfg(feature = "tick_event")]
             tick_event_rx: self.tick_event_rx.clone(),
             #[cfg(feature = "timer_registration")]
@@ -127,15 +130,19 @@ where
 
     pub fn spawn_local<T>(
         &self,
-        identifier: impl Into<TaskIdentifier>,
+        user_id: impl Into<UserId>,
         future: impl Future<Output = T> + 'static,
     ) -> Task<T>
     where
         T: 'static,
     {
-        let identifier = identifier.into();
-        let future = self.droppable_future(identifier.clone(), future);
-        let schedule = self.runnable_schedule_cb(identifier);
+        let next_id = self.counter.get() + 1;
+        let task_id = self.counter.replace(next_id);
+        let user_id = user_id.into();
+        let task_id = TaskId { task_id, user_id };
+
+        let future = self.droppable_future(task_id.clone(), future);
+        let schedule = self.runnable_schedule_cb(task_id);
         let (runnable, task) = async_task::spawn_local(future, schedule);
         runnable.schedule();
         task
@@ -162,7 +169,7 @@ where
 
     fn droppable_future<F>(
         &self,
-        identifier: TaskIdentifier,
+        task_id: TaskId,
         future: F,
     ) -> DroppableFuture<F, impl Fn() + use<F, O>>
     where
@@ -172,25 +179,22 @@ where
 
         // Spawn Task
         self.num_spawned_tasks.fetch_add(1, Ordering::Relaxed);
-        observer(TaskState::Spawn(identifier.clone()));
+        observer(TaskState::Spawn(task_id.clone()));
 
         // Droppable Future registering on_drop callback
         let num_spawned_tasks = self.num_spawned_tasks.clone();
         DroppableFuture::new(future, move || {
             num_spawned_tasks.fetch_sub(1, Ordering::Relaxed);
-            observer(TaskState::Drop(identifier.clone()));
+            observer(TaskState::Drop(task_id.clone()));
         })
     }
 
-    fn runnable_schedule_cb(
-        &self,
-        identifier: TaskIdentifier,
-    ) -> impl Fn(async_task::Runnable) + use<O> {
+    fn runnable_schedule_cb(&self, task_id: TaskId) -> impl Fn(async_task::Runnable) + use<O> {
         let task_tx = self.task_tx.clone();
         let observer = self.observer.clone();
         move |runnable| {
-            task_tx.send((identifier.clone(), runnable)).unwrap_or(());
-            observer(TaskState::Wake(identifier.clone()));
+            task_tx.send((task_id.clone(), runnable)).unwrap_or(());
+            observer(TaskState::Wake(task_id.clone()));
         }
     }
 }

--- a/src/split_ticked_async_executor.rs
+++ b/src/split_ticked_async_executor.rs
@@ -219,10 +219,6 @@ impl<O> TickedAsyncExecutorTicker<O>
 where
     O: Fn(TaskState),
 {
-    pub fn delta(&self) -> TickedAsyncExecutorDelta {
-        TickedAsyncExecutorDelta(self.delta.clone())
-    }
-
     pub fn tick(&mut self, delta: f64, limit: Option<usize>) {
         self.delta.replace(delta);
 

--- a/src/split_ticked_async_executor.rs
+++ b/src/split_ticked_async_executor.rs
@@ -171,7 +171,7 @@ where
         &self,
         task_id: TaskId,
         future: F,
-    ) -> DroppableFuture<F, impl Fn() + use<F, O>>
+    ) -> DroppableFuture<F, impl FnOnce() + use<F, O>>
     where
         F: Future,
     {
@@ -185,7 +185,7 @@ where
         let num_spawned_tasks = self.num_spawned_tasks.clone();
         DroppableFuture::new(future, move || {
             num_spawned_tasks.fetch_sub(1, Ordering::Relaxed);
-            observer(TaskState::Drop(task_id.clone()));
+            observer(TaskState::Drop(task_id));
         })
     }
 

--- a/src/task_identifier.rs
+++ b/src/task_identifier.rs
@@ -1,43 +1,49 @@
 use std::sync::Arc;
 
-/// Cheaply clonable TaskIdentifier
 #[derive(Debug, Clone)]
-pub enum TaskIdentifier {
+pub struct TaskId {
+    pub task_id: u64,
+    pub user_id: UserId,
+}
+
+/// Cheaply clonable UserId
+#[derive(Debug, Clone)]
+pub enum UserId {
     None,
     Literal(&'static str),
     Arc(Arc<String>),
 }
 
-impl From<()> for TaskIdentifier {
+impl From<()> for UserId {
     fn from(_value: ()) -> Self {
         Self::None
     }
 }
 
-impl From<&'static str> for TaskIdentifier {
+impl From<&'static str> for UserId {
     fn from(value: &'static str) -> Self {
         Self::Literal(value)
     }
 }
 
-impl From<String> for TaskIdentifier {
+impl From<String> for UserId {
     fn from(value: String) -> Self {
         Self::Arc(Arc::new(value))
     }
 }
 
-impl From<Arc<String>> for TaskIdentifier {
+impl From<Arc<String>> for UserId {
     fn from(value: Arc<String>) -> Self {
         Self::Arc(value.clone())
     }
 }
 
-impl std::fmt::Display for TaskIdentifier {
+impl std::fmt::Display for UserId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            TaskIdentifier::None => write!(f, "[None]"),
-            TaskIdentifier::Literal(data) => write!(f, "{data}"),
-            TaskIdentifier::Arc(data) => write!(f, "{data}"),
+            UserId::None => write!(f, "[None]"),
+            UserId::Literal(data) => write!(f, "{data}"),
+            UserId::Arc(data) => write!(f, "{data}"),
         }
     }
 }
@@ -48,18 +54,18 @@ mod tests {
 
     #[test]
     fn test_display() {
-        let identifier = TaskIdentifier::from(());
+        let identifier = UserId::from(());
         assert_eq!(identifier.to_string(), "[None]");
 
-        let identifier = TaskIdentifier::from("Hello World");
+        let identifier = UserId::from("Hello World");
         assert_eq!(identifier.to_string(), "Hello World");
 
         let identifier = "Hello World".to_owned();
-        let identifier = TaskIdentifier::from(identifier);
+        let identifier = UserId::from(identifier);
         assert_eq!(identifier.to_string(), "Hello World");
 
         let identifier = Arc::new("Hello World".to_owned());
-        let identifier = TaskIdentifier::from(identifier);
+        let identifier = UserId::from(identifier);
         assert_eq!(identifier.to_string(), "Hello World");
     }
 }

--- a/src/ticked_async_executor.rs
+++ b/src/ticked_async_executor.rs
@@ -1,7 +1,7 @@
 use std::future::Future;
 
 use crate::{
-    SplitTickedAsyncExecutor, Task, TaskIdentifier, TaskState, TickedAsyncExecutorDelta,
+    SplitTickedAsyncExecutor, Task, UserId, TaskState, TickedAsyncExecutorDelta,
     TickedAsyncExecutorSpawner, TickedAsyncExecutorTicker,
 };
 
@@ -27,7 +27,7 @@ where
 
     pub fn spawn_local<T>(
         &self,
-        identifier: impl Into<TaskIdentifier>,
+        identifier: impl Into<UserId>,
         future: impl Future<Output = T> + 'static,
     ) -> Task<T>
     where

--- a/src/ticked_async_executor.rs
+++ b/src/ticked_async_executor.rs
@@ -1,8 +1,8 @@
 use std::future::Future;
 
 use crate::{
-    SplitTickedAsyncExecutor, Task, UserId, TaskState, TickedAsyncExecutorDelta,
-    TickedAsyncExecutorSpawner, TickedAsyncExecutorTicker,
+    SplitTickedAsyncExecutor, Task, TaskState, TickedAsyncExecutorDelta,
+    TickedAsyncExecutorSpawner, TickedAsyncExecutorTicker, UserId,
 };
 
 pub struct TickedAsyncExecutor<O> {
@@ -41,7 +41,7 @@ where
     }
 
     pub fn delta(&self) -> TickedAsyncExecutorDelta {
-        self.ticker.delta()
+        self.spawner.delta()
     }
 
     /// Run the woken tasks once


### PR DESCRIPTION
# Main
- Instead of User defined TaskIdentifier, make a distinction between TaskId (provided by the executor) and UserId (provided by the user)

# Misc
- Delta is provided by spawner instead of ticker
- Make DroppableFuture `on_drop` FnOnce instead of Fn